### PR TITLE
Add purge CDN step to upload-azure-static

### DIFF
--- a/upload-azure-static/README.md
+++ b/upload-azure-static/README.md
@@ -18,7 +18,7 @@ See the [action.yml](./action.yml) file for parameter info.
 ```yaml
 uses: ObamaFoundation/actions/upload-static@v1.0
 with:
-  deploy-prefix: dev
+  az-storage-account: 'blueobamaorg'
 ```
 
 The complete interface with defaults is as follows:
@@ -26,8 +26,9 @@ The complete interface with defaults is as follows:
 ```yaml
 uses: ObamaFoundation/actions/upload-static@v1.0
 with:
-  deploy-prefix: # No Default (Required)
+  az-storage-account: # No Default (Required)
   az-storage-container: # Default '$web'
   paths: # Default 'build'
   delete-destination: # Default 'true'
+  cdn-base-name: # Default is blank, which does not purge CDN
 ```

--- a/upload-azure-static/action.yml
+++ b/upload-azure-static/action.yml
@@ -2,8 +2,8 @@ name: "Upload to Azure Storage"
 description: "Uploads file paths to Azure Blob Storage using `sync`"
 
 inputs:
-  deploy-prefix:
-    description: 'Deploy prefix used for storage account and CDN'
+  az-storage-account:
+    description: 'Azure Blob Storage account name'
     required: true
   az-storage-container:
     description: 'Azure Blob Storage container name'
@@ -14,6 +14,8 @@ inputs:
   delete-destination:
     description: "Delete destination files not in source"
     default: 'true'
+  cdn-base-name:
+    description: 'Base name for CDN name and profile. Leave blank to skip purging CDN.'
 
 runs: 
   using: composite
@@ -23,12 +25,13 @@ runs:
     with:
       inlineScript: |
         az storage blob sync \
-          --account-name ${{ inputs.deploy-prefix }}obamaorg \
+          --account-name ${{ inputs.az-storage-account }} \
           --container ${{ inputs.az-storage-container }} \
           --source ${{ inputs.paths }} \
           --delete-destination ${{ inputs.delete-destination }}
   - name: Purge CDN endpoint
+    if: ${{ inputs.cdn-base-name }}
     uses: azure/CLI@v1
     with:
       inlineScript: |
-        az cdn endpoint purge --content-paths "/*" --profile-name "${{ inputs.deploy-prefix }}-obama-org-CDN" --name "${{ inputs.deploy-prefix }}-obama-org" --resource-group "of-obama-org"
+        az cdn endpoint purge --content-paths "/*" --profile-name "${{ inputs.cdn-base-name }}-obama-org-CDN" --name "${{ inputs.cdn-base-name }}-obama-org" --resource-group "of-obama-org"


### PR DESCRIPTION
# Description of Changes

- Add optional purge CDN step to the `upload-azure-static` workflow.
- Add `cdn-base-name` input to specify CDN to purge. Or blank to skip purging CDN.
