### PR TITLE
Deploy preview app from "preview" subdir

### DIFF
--- a/deploy-azure-preview/action.yml
+++ b/deploy-azure-preview/action.yml
@@ -17,7 +17,7 @@ runs:
       with:
         app-name: obamaorg-preview
         publish-profile: ${{ inputs.azure-publish-profile }}
-        package: .
+        package: ./preview
         slot-name: ${{ inputs.slot-name }}
     
     - name: Upload to production Webapp
@@ -26,4 +26,4 @@ runs:
       with:
         app-name: obamaorg-preview
         publish-profile: ${{ inputs.azure-publish-profile }}
-        package: .
+        package: ./preview


### PR DESCRIPTION
# Description of Changes

- Since unzip preserves the directory structure, the preview app deploy needs to specify the "preview" subdir. This issue was discovered during the staging deploy on 5/9.
