### PR TITLE
Faster Azure upload

### DIFF
--- a/upload-azure-static/README.md
+++ b/upload-azure-static/README.md
@@ -39,5 +39,5 @@ with:
   az-subscription-id: # No Default (Required)
   az-storage-account: # No Default (Required)
   az-storage-container: # Default '$web'
-  paths: # Default 'build'
+  path: # Default 'build'
 ```

--- a/upload-azure-static/action.yml
+++ b/upload-azure-static/action.yml
@@ -11,8 +11,8 @@ inputs:
   az-storage-container:
     description: "Azure Blob Storage container name"
     default: "$web"
-  paths:
-    description: "File paths to upload"
+  path:
+    description: "File path to upload"
     default: "build"
 
 runs:
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         az storage copy \
-          '-s=${{ inputs.paths }}/*' \
+          '-s=${{ inputs.path }}/*' \
           '-d=https://${{ inputs.az-storage-account }}.blob.core.windows.net/${{ inputs.az-storage-container }}' \
           --subscription=${{ inputs.az-subscription-id }} \
           --recursive \
@@ -36,7 +36,7 @@ runs:
         az storage blob sync \
           --account-name=${{ inputs.az-storage-account }} \
           '--container=${{ inputs.az-storage-container }}' \
-          --source=${{ inputs.paths }} \
+          --source=${{ inputs.path }} \
           | tee tmp_sync_output.txt
 
     - name: Print summary


### PR DESCRIPTION
# Description of Changes

Use `az storage copy` command to make upload significantly faster, about 15 sec vs. 3.5 minutes previously.

* Instead of using the `azure/CLI@v1` action twice, call the `az storage` command directly from the shell. The Azure
action loads a Docker image and (I think) logs in again, which we don't need. Since we've already logged in, those
credentials can be used by the command. Another speed-up was gained by copying the html files first and then
syncing. This seems to be much faster.
* Added required `az-subscription-id` input, which is needed by the `az storage` command. This will require bumping the action (minor?) version.
* Removed the delete-destination and cdn-base-name inputs. We don't use the first and the second was supposed to trigger a CDN purge, which we now do in a separate step.
* Also add more info to the summary, including a link to the deployed site.

Example run:
https://github.com/ObamaFoundation/obamaorg-swa/actions/runs/5223491157/jobs/9430826822