### PR TITLE
Upgrade to Node v18

### DIFF
--- a/node-npm/action.yml
+++ b/node-npm/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'npm'
 
     - name: Install dependencies


### PR DESCRIPTION
# Description of Changes

This change will be tagged as "v2.1" in this repo. The obamaorg-swa repo is currently using node-npm@v1, so the switch to Node v18 will be done by updating the version there.
