### PR TITLE
Simplify instructions for creating a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,8 @@ For info on the @actions toolkit helpers see the
 
 ## Tags
 
-The version tags follow semver.org with the expectation that workflows will specify a major version,
-e.g. `@v1`. To tag a commit:
-
-* Merge your change into `main` branch.
-* `git checkout main`
-* `git pull --tags -f`
-* Look at https://github.com/ObamaFoundation/actions/tags and use the next highest major, minor, or patch version below as X, Y, and Z (e.g. v1.0.9):
-* `git tag -a -m "Explain the changes" vX.Y.Z`
-* `git push -f --tags`
-* If you've made large changes, this is a good point to test them. Changing the major and minor tags could break workflows.
-  * In `obamaorg-swa` repo on a new branch, change all with regex `(ObamaFoundation/actions/.*)@v1` to your new version `$1@vX.Y.Z` in the `.github` directory.
-  * Push the change and create a temporary pull request, which will fire off a build.
-  * Make sure the build succeeds.
-  * Delete the temporary pull request.
-  * Continue below.
-* While still on `main` branch, move the minor release with: `git tag -f vX.Y`
-* And major release: `git tag -f vX`
-* Push thoses tag changes: `git push -f --tags`
-
-Note: To see where a tag is currently pointing (locally): `git rev-list -n 1 vX.Y.Z`.
+After making changes to the actions, create a new release selecting a new tag with the next higher semver as appropriate.
+(Phasing out use of the tag aliases. They are too confusing to update and track.)
 
 ## Testing
 


### PR DESCRIPTION
# Description of Changes

Instead of all the complicated commands to create and move tags, just create a new release with a new tag.
