### PR TITLE
Change tagging strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To tag a commit:
   * Delete the temporary pull request.
   * Continue below.
 * While still on `main` branch in the `actions` repo, move the minor release with: `git tag -f <vX.Y>`
-* And push that tag change: `git push origin <vX.Y>`
+* And push that tag change: `git push -f origin <vX.Y>`
 
 Note: To see where a tag is currently pointing (locally): `git rev-list -n 1 vX.Y.Z`.
 


### PR DESCRIPTION
# Description of Changes

- Change tagging strategy to say that workflows will use major and minor version.
- Remove instructions for moving major version, e.g. v2. We're going to use minor version instead.
- Improve tag push instructions to be safer (instead of force pushing all tags, which could be a disaster).
- Add tip for testing.