### PR TITLE
Add step to node-npm action to create .npmrc

### DIFF
--- a/node-npm/action.yml
+++ b/node-npm/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Create .npmrc
       if: inputs.read-packages-token
       shell: bash
-      run: "[ -f .npmrc.example ] && cp .npmrc.example .npmrc && sed -i 's/<gh_read_packages_token_from_lastpass>/${ inputs.read-packages-token }/g' .npmrc"
+      run: "[ -f .npmrc.example ] && cp .npmrc.example .npmrc && sed -i 's/<gh_read_packages_token_from_lastpass>/${{ inputs.read-packages-token }}/g' .npmrc"
     - name: Install dependencies
       shell: bash
       run: npm ci


### PR DESCRIPTION
# Description of Changes

- Adds an optional step that copies .npmrc from .npmrc-example and inserts the read:packages Github token.

Tested with obamaorg-swa. This will be included in a patch version release since it's a minor change and backward compatible.