### PR TITLE
Simplify the auth for GH npm registry

### DIFF
--- a/node-npm/action.yml
+++ b/node-npm/action.yml
@@ -12,10 +12,9 @@ runs:
       with:
         node-version: 20
         cache: 'npm'
-    - name: Create .npmrc
-      if: inputs.read-packages-token
-      shell: bash
-      run: "[ -f .npmrc.example ] && cp .npmrc.example .npmrc && sed -i 's/<gh_read_packages_token_from_lastpass>/${{ inputs.read-packages-token }}/g' .npmrc"
+        registry-url: https://npm.pkg.github.com/
     - name: Install dependencies
       shell: bash
       run: npm ci
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.read-packages-token }}


### PR DESCRIPTION
# Description of Changes

- Simplify the auth for GitHub npm registry using the built-in parameter in the setup-node action.

Tested by deploying to personal dev env while pointing to this branch. https://github.com/ObamaFoundation/obamaorg-swa/actions/runs/7399245594
