### PR TITLE
Warn instead of fail on invalid JSON

### DIFF
--- a/health-check/dist/index.js
+++ b/health-check/dist/index.js
@@ -26012,7 +26012,7 @@ function doCheck(endpoint, jsonAssertions, elapsedTime) {
                 }
                 catch (error) {
                     logFailure("Invalid JSON from endpoint: " + error.toString());
-                    core.setFailed("Invalid JSON from endpoint");
+                    core.warning("Invalid JSON from endpoint");
                     return false;
                 }
                 jsonAssertions.forEach((assertion) => {

--- a/health-check/dist/index.js
+++ b/health-check/dist/index.js
@@ -26036,7 +26036,6 @@ function doCheck(endpoint, jsonAssertions, elapsedTime) {
             }
         }
         catch (error) {
-            logFailure(`Action failed with error ${error}`);
             core.warning(`Action failed with error ${error}`);
             return false;
         }

--- a/health-check/dist/index.js
+++ b/health-check/dist/index.js
@@ -26015,10 +26015,17 @@ function doCheck(endpoint, jsonAssertions, elapsedTime) {
                     core.warning("Invalid JSON from endpoint");
                     return false;
                 }
-                jsonAssertions.forEach((assertion) => {
-                    const { left, op, right } = (0,assertions/* parse */.Q)(assertion);
-                    results.push((0,assertions/* assert */.h)({ left: json[left], op, right }));
-                });
+                try {
+                    jsonAssertions.forEach((assertion) => {
+                        const { left, op, right } = (0,assertions/* parse */.Q)(assertion);
+                        results.push((0,assertions/* assert */.h)({ left: json[left], op, right }));
+                    });
+                }
+                catch (error) {
+                    logFailure(error);
+                    core.setFailed(error);
+                    return true;
+                }
             }
             if (results.some((r) => r.result == "fail")) {
                 console.log("Assertions failed.");

--- a/health-check/dist/index.js
+++ b/health-check/dist/index.js
@@ -26023,7 +26023,7 @@ function doCheck(endpoint, jsonAssertions, elapsedTime) {
                 }
                 catch (error) {
                     logFailure(error);
-                    core.setFailed(error);
+                    core.setFailed(`Action failed with error ${error}`);
                     return true;
                 }
             }

--- a/health-check/dist/index.js
+++ b/health-check/dist/index.js
@@ -26030,7 +26030,7 @@ function doCheck(endpoint, jsonAssertions, elapsedTime) {
         }
         catch (error) {
             logFailure(`Action failed with error ${error}`);
-            core.setFailed(`Action failed with error ${error}`);
+            core.warning(`Action failed with error ${error}`);
             return false;
         }
         checkInProgress = false;

--- a/health-check/src/main.test.ts
+++ b/health-check/src/main.test.ts
@@ -48,12 +48,14 @@ vi.mock("@actions/core", () => {
 
 let spySetFailed;
 let spyAddTable;
+let spyWarning;
 
 describe("health check", () => {
   beforeEach(() => {
     mockValues = Object.assign({}, mockInitialValues);
     spySetFailed = vi.spyOn(core, "setFailed");
     spyAddTable = vi.spyOn(core.summary, "addTable");
+    spyWarning = vi.spyOn(core, "warning");
     setTimeoutLimit(150);
     setSleepTime(50);
   });
@@ -117,7 +119,7 @@ describe("health check", () => {
     ];
 
     await main();
-    expect(spySetFailed).toHaveBeenCalledWith("Invalid JSON from endpoint");
+    expect(spyWarning).toHaveBeenCalledWith("Invalid JSON from endpoint");
     expect(spyAddTable).not.toHaveBeenCalled();
   });
 });

--- a/health-check/src/main.test.ts
+++ b/health-check/src/main.test.ts
@@ -104,8 +104,7 @@ describe("health check", () => {
       "userId ?? 1",
       "completed == false",
     ];
-    const spyWarning = vi.spyOn(core, "warning");
-
+    
     await main();
     expect(spyWarning).toHaveBeenCalled();
     expect(spySetFailed).toHaveBeenCalledWith("Action failed with error Error: Invalid assertion: userId ?? 1. No valid Operator found.");

--- a/health-check/src/main.ts
+++ b/health-check/src/main.ts
@@ -82,7 +82,7 @@ async function doCheck(endpoint: string, jsonAssertions: string[], elapsedTime: 
         });
       } catch (error) {
         logFailure(error);
-        core.setFailed(error);
+        core.setFailed(`Action failed with error ${error}`);
         return true;
       }
     }

--- a/health-check/src/main.ts
+++ b/health-check/src/main.ts
@@ -75,10 +75,16 @@ async function doCheck(endpoint: string, jsonAssertions: string[], elapsedTime: 
         return false;
       }
 
-      jsonAssertions.forEach((assertion) => {
-        const { left, op, right } = parse(assertion);
-        results.push(assert({ left: json[left], op, right }));
-      });
+      try {
+        jsonAssertions.forEach((assertion) => {
+          const { left, op, right } = parse(assertion);
+          results.push(assert({ left: json[left], op, right }));
+        });
+      } catch (error) {
+        logFailure(error);
+        core.setFailed(error);
+        return true;
+      }
     }
 
     if (results.some((r) => r.result == "fail")) {

--- a/health-check/src/main.ts
+++ b/health-check/src/main.ts
@@ -90,7 +90,7 @@ async function doCheck(endpoint: string, jsonAssertions: string[], elapsedTime: 
     }
   } catch (error) {
     logFailure(`Action failed with error ${error}`);
-    core.setFailed(`Action failed with error ${error}`);
+    core.warning(`Action failed with error ${error}`);
     return false;
   }
   checkInProgress = false;

--- a/health-check/src/main.ts
+++ b/health-check/src/main.ts
@@ -71,7 +71,7 @@ async function doCheck(endpoint: string, jsonAssertions: string[], elapsedTime: 
         json = JSON.parse(responseText);
       } catch (error) {
         logFailure("Invalid JSON from endpoint: " + error.toString());
-        core.setFailed("Invalid JSON from endpoint");
+        core.warning("Invalid JSON from endpoint");
         return false;
       }
 

--- a/health-check/src/main.ts
+++ b/health-check/src/main.ts
@@ -95,7 +95,6 @@ async function doCheck(endpoint: string, jsonAssertions: string[], elapsedTime: 
       return false;
     }
   } catch (error) {
-    logFailure(`Action failed with error ${error}`);
     core.warning(`Action failed with error ${error}`);
     return false;
   }


### PR DESCRIPTION
# Description of Changes

This small PR warns instead of failing when the JSON returned from the health check input is invalid. It also updates a test as needed. I've also gone back and updated the overall check to NOT fail when there's some unexplained error. My reasoning?

We recently started seeing a different error (`TypeError: terminated`) for the health check for the preview app. I suspect that this error is related to a failed fetch request as the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) shows that this is one of the possible errors you can get when a fetch fails. I'm assuming there's a network error when trying to access the newly restarted app; network errors are indeed one of the potential reasons listed in the docs for this specific error.

I'm hoping that this cuts down (or outright eliminates) on these health check errors for the preview app. 

Here's [an example of a workflow](https://github.com/ObamaFoundation/obamaorg-swa/actions/runs/18203372606/job/51827575062?pr=2864) where this new logic allowed the health check to continue until the request was successful.

- ...

Closes #
